### PR TITLE
Monitoring progress events for uploads.

### DIFF
--- a/src/Native/Http.js
+++ b/src/Native/Http.js
@@ -57,6 +57,19 @@ function toTask(request, maybeProgress)
 	});
 }
 
+function handleProgress(event, maybeProgress)
+{
+	if (!event.lengthComputable)
+	{
+		return;
+	}
+
+	_elm_lang$core$Native_Scheduler.rawSpawn(maybeProgress._0({
+		bytes: event.loaded,
+		bytesExpected: event.total
+	}));
+}
+
 function configureProgress(xhr, maybeProgress)
 {
 	if (maybeProgress.ctor === 'Nothing')
@@ -64,15 +77,14 @@ function configureProgress(xhr, maybeProgress)
 		return;
 	}
 
+	if (xhr.upload) {
+		xhr.upload.addEventListener('progress', function(event) {
+			handleProgress(event, maybeProgress);
+		});
+	}
+
 	xhr.addEventListener('progress', function(event) {
-		if (!event.lengthComputable)
-		{
-			return;
-		}
-		_elm_lang$core$Native_Scheduler.rawSpawn(maybeProgress._0({
-			bytes: event.loaded,
-			bytesExpected: event.total
-		}));
+		handleProgress(event, maybeProgress);
 	});
 }
 


### PR DESCRIPTION
I think progress events in the future should be split to two types `DownloadProgress` and `UploadProgress`. This PR for now allows users to monitor upload progress until then.

Even if it's not merged it's a good way to show how it can be done.

Based on: https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Submitting_forms_and_uploading_files
> Progress events exist for both download and upload transfers. The download events are fired on the XMLHttpRequest object itself, as shown in the above sample. The upload events are fired on the XMLHttpRequest.upload object